### PR TITLE
Module updated with a shim.h header

### DIFF
--- a/module.modulemap
+++ b/module.modulemap
@@ -13,24 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
- 
+
 module OpenSSL [system] {
-       header "/usr/include/openssl/conf.h"
-       header "/usr/include/openssl/evp.h"
-       header "/usr/include/openssl/err.h"
-       header "/usr/include/openssl/bio.h"
-       header "/usr/include/openssl/ssl.h"
-       header "/usr/include/openssl/md4.h"
-       header "/usr/include/openssl/md5.h"
-       header "/usr/include/openssl/sha.h"
-       header "/usr/include/openssl/rsa.h"
-       header "/usr/include/openssl/hmac.h"
-       header "/usr/include/openssl/rand.h"
-       header "/usr/include/openssl/pem.h"
-       header "/usr/include/openssl/engine.h"
-       header "/usr/include/openssl/objects.h"
-       header "/usr/include/openssl/pkcs12.h" 
-       header "/usr/include/openssl/x509v3.h" 
+       header "shim.h" 
        link "ssl"
        link "crypto"
-}    
+}

--- a/shim.h
+++ b/shim.h
@@ -1,0 +1,58 @@
+/**
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#ifndef OpenSSLHelper_h
+#define OpenSSLHelper_h
+
+#include <openssl/conf.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <openssl/bio.h>
+#include <openssl/ssl.h>
+#include <openssl/md4.h>
+#include <openssl/md5.h>
+#include <openssl/sha.h>
+#include <openssl/hmac.h>
+#include <openssl/rand.h>
+#include <openssl/pkcs12.h>
+#include <openssl/x509v3.h>
+
+// This is a wrapper function to wrap the call to SSL_CTX_set_alpn_select_cb() which is
+// only available from OpenSSL v1.0.2. Calling this function with older version will do
+// nothing.
+static inline SSL_CTX_set_alpn_select_cb_wrapper(SSL_CTX *ctx,
+					  int (*cb) (SSL *ssl,
+								 const unsigned char **out,
+								 unsigned char *outlen,
+								 const unsigned char *in,
+								 unsigned int inlen,
+								 void *arg), void *arg) {
+	#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+		SSL_CTX_set_alpn_select_cb(ctx, cb, arg);
+	#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
+}
+
+// This is a wrapper function to wrap the call to SSL_get0_alpn_selected() which is
+// only available from OpenSSL v1.0.2. Calling this function with older version will do
+// nothing.
+static inline SSL_get0_alpn_selected_wrapper(const SSL *ssl, const unsigned char **data,
+											 unsigned int *len) {
+	#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+		SSL_get0_alpn_selected(ssl, data, len);
+	#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
+}
+
+#endif


### PR DESCRIPTION
1. Created a shim.h header file that holds the openssl includes. @shmuelk suggested this approach as it is platform-independent and does not use absolute paths to the included openssl header files.
2. Added two inline wrapper functions for future ALPN support that only being invoked if the OpenSSL version is 1.0.2 and above.