### PR TITLE
Added wrapper for OpenSSL 1.0.1 issue on 14.04

### DIFF
--- a/shim.h
+++ b/shim.h
@@ -70,12 +70,12 @@ static inline int SSL_EVP_digestVerifyFinal_wrapper(EVP_MD_CTX *ctx, const unsig
 
 	//If version higher than 1.0.2 then it needs to use immutable version of sig
 	#if (OPENSSL_VERSION_NUMBER >= 0x1000200fL)
-		return EVP_DigestVerifyFinal(ctx, sig, siglen)
+		return EVP_DigestVerifyFinal(ctx, sig, siglen);
 	#else
 		// Need to make sig immutable for under 1.0.2
 		//mutable int * newPointer = sig
-		
-		return EVP_DigestVerifyFinal(ctx, sig, siglen)
+
+		return EVP_DigestVerifyFinal(ctx, sig, siglen);
 	#endif
 
 }

--- a/shim.h
+++ b/shim.h
@@ -73,8 +73,6 @@ static inline int SSL_EVP_digestVerifyFinal_wrapper(EVP_MD_CTX *ctx, const unsig
 		return EVP_DigestVerifyFinal(ctx, sig, siglen);
 	#else
 		// Need to make sig immutable for under 1.0.2
-		//mutable int * newPointer = sig
-
 		return EVP_DigestVerifyFinal(ctx, sig, siglen);
 	#endif
 

--- a/shim.h
+++ b/shim.h
@@ -58,11 +58,26 @@ static inline SSL_get0_alpn_selected_wrapper(const SSL *ssl, const unsigned char
 // This is a wrapper function that allows the setting of AUTO ECDH mode when running
 // on OpenSSL v1.0.2. Calling this function on an older version will have no effect.
 static inline SSL_CTX_setAutoECDH(SSL_CTX *ctx) {
-	
+
 	#if (OPENSSL_VERSION_NUMBER >= 0x1000200fL && OPENSSL_VERSION_NUMBER < 0x10100000L)
 		SSL_CTX_ctrl(ctx, SSL_CTRL_SET_ECDH_AUTO, 1, NULL);
 	#endif
 }
 
+// This is a wrapper function that allows older versions of OpenSSL, that use mutable
+// pointers to work alongside newer versions of it that use an immutable pointer.
+static inline int SSL_EVP_digestVerifyFinal_wrapper(EVP_MD_CTX *ctx, const unsigned char *sig, size_t siglen) {
+
+	//If version higher than 1.0.2 then it needs to use immutable version of sig
+	#if (OPENSSL_VERSION_NUMBER >= 0x1000200fL)
+		return EVP_DigestVerifyFinal(ctx, sig, siglen)
+	#else
+		// Need to make sig immutable for under 1.0.2
+		//mutable int * newPointer = sig
+		
+		return EVP_DigestVerifyFinal(ctx, sig, siglen)
+	#endif
+
+}
 
 #endif


### PR DESCRIPTION
There was an issue causing a failure when 14.04 used OpenSSL 1.0.1, due to the signature of a method changing. Swift would throw an error, so a wrapper in this PR has fixed the issue.

For reference, heres the failing Travis build: https://travis-ci.org/IBM-Swift/BlueRSA/jobs/396377103
And here is a new build on a new PR for BlueRSA, using the branch: https://travis-ci.org/IBM-Swift/BlueRSA/jobs/408132429