### PR TITLE
Restore providers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,12 @@ let package = Package(
         )
     ],
     targets: [
-        .systemLibrary(name: "OpenSSL"),
+        .systemLibrary(
+            name: "OpenSSL",
+            providers: [
+                .apt(["openssl libssl-dev"]),
+                .brew(["openssl"]),
+            ]
+        )
     ]
 )


### PR DESCRIPTION
#9 restructured the package into a Swift 4.2 format system library target, but lost the `providers` array.

This PR restores it (now belongs on the system library target itself, not the overall package).