### PR TITLE
Support for openssl 1.1.x

### DIFF
--- a/Sources/OpenSSL/shim.h
+++ b/Sources/OpenSSL/shim.h
@@ -78,4 +78,42 @@ static inline int SSL_EVP_digestVerifyFinal_wrapper(EVP_MD_CTX *ctx, const unsig
 
 }
 
+// Initialize OpenSSL
+static inline void OpenSSL_SSL_init(void) {
+
+        SSL_library_init();
+        SSL_load_error_strings();
+        OPENSSL_config(NULL);
+        OPENSSL_add_all_algorithms_conf();
+}
+
+// This is a wrapper function to get server SSL_METHOD based on OpenSSL version.
+static inline const SSL_METHOD *OpenSSL_server_method(void) {
+
+	#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+	        return SSLv23_server_method();
+	#else
+		return TLS_server_method();
+	#endif
+}
+
+// This is a wrapper function to get client SSL_METHOD based on OpenSSL version.
+static inline const SSL_METHOD *OpenSSL_client_method(void) {
+
+        #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+                return SSLv23_client_method();
+        #else
+                return TLS_client_method();
+        #endif
+}
+
+static inline long OpenSSL_SSL_CTX_set_mode(SSL_CTX *context, long mode) {
+        return SSL_CTX_set_mode(context, mode);
+}
+
+static inline long OpenSSL_SSL_CTX_set_options(SSL_CTX *context) {
+        return SSL_CTX_set_options(context, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION);
+}
+
+
 #endif


### PR DESCRIPTION
**Motivation:** 

Currently, BlueSSLService doesn't add support for openssl 1.1.X. This PR aims to add support for both openssl versions 1.0.X and 1.1.X

