### PR TITLE
Add pkgConfig for openssl

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
     targets: [
         .systemLibrary(
             name: "OpenSSL",
+            pkgConfig: "openssl",
             providers: [
                 .apt(["openssl libssl-dev"]),
                 .brew(["openssl"]),


### PR DESCRIPTION
With this we can remove the dependency on [https://github.com/IBM-Swift/OpenSSL-OSX](url) on OSX 

Ref: https://github.com/ibm-cloud-security/Swift-JWK-to-PEM/pull/7
Passing travis : https://travis-ci.org/ibm-cloud-security/Swift-JWK-to-PEM/builds/466092144?utm_source=github_status&utm_medium=notification