### PR TITLE
feat: Add EVP_CIPHER_CTX_init_wrapper 

### DIFF
--- a/Sources/OpenSSL/shim.h
+++ b/Sources/OpenSSL/shim.h
@@ -143,7 +143,7 @@ static inline int HMAC_Init_wrapper(HMAC_CTX *ctx, const void *key, int len, con
                 return HMAC_Init_ex(ctx, key, len, md, NULL);
         #else
                 return HMAC_Init(ctx, key, len, md);
-        #endif	
+        #endif
 }
 
 // This wrapper allows for a common call for both versions of OpenSSL when creating a new EVP_MD_CTX.
@@ -173,6 +173,14 @@ static inline EVP_CIPHER_CTX *EVP_CIPHER_CTX_new_wrapper(void) {
                 return EVP_CIPHER_CTX_new();
         #else
                 return malloc(sizeof(EVP_CIPHER_CTX));
+        #endif
+}
+
+// This wrapper allows for a common call for both versions of OpenSSL when initalizing an EVP_CIPHER_CTX since EVP_CIPHER_CTX_init was removed in 1.1.
+static inline EVP_CIPHER_CTX_init_wrapper(EVP_CIPHER_CTX *ctx) {
+
+        #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+                return EVP_CIPHER_CTX_init(ctx);
         #endif
 }
 

--- a/Sources/OpenSSL/shim.h
+++ b/Sources/OpenSSL/shim.h
@@ -176,7 +176,7 @@ static inline EVP_CIPHER_CTX *EVP_CIPHER_CTX_new_wrapper(void) {
         #endif
 }
 
-// This wrapper allows for a common call for both versions of OpenSSL when initalizing an EVP_CIPHER_CTX
+// This wrapper allows for a common call for both versions of OpenSSL when initalizing an EVP_CIPHER_CTX.
 static inline void EVP_CIPHER_CTX_init_wrapper(EVP_CIPHER_CTX *ctx) {
 
     #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)

--- a/Sources/OpenSSL/shim.h
+++ b/Sources/OpenSSL/shim.h
@@ -176,12 +176,14 @@ static inline EVP_CIPHER_CTX *EVP_CIPHER_CTX_new_wrapper(void) {
         #endif
 }
 
-// This wrapper allows for a common call for both versions of OpenSSL when initalizing an EVP_CIPHER_CTX since EVP_CIPHER_CTX_init was removed in 1.1.
+// This wrapper allows for a common call for both versions of OpenSSL when initalizing an EVP_CIPHER_CTX
 static inline void EVP_CIPHER_CTX_init_wrapper(EVP_CIPHER_CTX *ctx) {
 
-        #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
-                EVP_CIPHER_CTX_init(ctx);
-        #endif
+    #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+            EVP_CIPHER_CTX_reset(ctx);
+    #else
+            EVP_CIPHER_CTX_init(ctx);
+    #endif
 }
 
 // This wrapper allows for a common call for both versions of OpenSSL when resetting an EVP_CIPHER_CTX.

--- a/Sources/OpenSSL/shim.h
+++ b/Sources/OpenSSL/shim.h
@@ -143,7 +143,7 @@ static inline int HMAC_Init_wrapper(HMAC_CTX *ctx, const void *key, int len, con
                 return HMAC_Init_ex(ctx, key, len, md, NULL);
         #else
                 return HMAC_Init(ctx, key, len, md);
-        #endif
+        #endif 
 }
 
 // This wrapper allows for a common call for both versions of OpenSSL when creating a new EVP_MD_CTX.

--- a/Sources/OpenSSL/shim.h
+++ b/Sources/OpenSSL/shim.h
@@ -177,10 +177,10 @@ static inline EVP_CIPHER_CTX *EVP_CIPHER_CTX_new_wrapper(void) {
 }
 
 // This wrapper allows for a common call for both versions of OpenSSL when initalizing an EVP_CIPHER_CTX since EVP_CIPHER_CTX_init was removed in 1.1.
-static inline EVP_CIPHER_CTX_init_wrapper(EVP_CIPHER_CTX *ctx) {
+static inline void EVP_CIPHER_CTX_init_wrapper(EVP_CIPHER_CTX *ctx) {
 
         #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
-                return EVP_CIPHER_CTX_init(ctx);
+                EVP_CIPHER_CTX_init(ctx);
         #endif
 }
 


### PR DESCRIPTION
The PR adds a wrapper for EVP_CIPHER_CTX_init so that it can be called from OpenSSL 1.0 and 1.1

In OpenSSL 1.0 you had to call EVP_CIPHER_CTX_init after creating a new cipher context. This is no longer the case and EVP_CIPHER_CTX_init is not used in 1.1.  Instead calls to EVP_CIPHER_CTX_init should just call EVP_CIPHER_CTX_reset.

https://www.openssl.org/docs/man1.1.0/man3/EVP_EncryptInit.html